### PR TITLE
adding convenience clear method for all registered loggers

### DIFF
--- a/src/main/java/slf4jtest/TestLoggerFactory.java
+++ b/src/main/java/slf4jtest/TestLoggerFactory.java
@@ -51,6 +51,15 @@ public class TestLoggerFactory implements LoggerFactoryExtensions {
         return false;
     }
 
+    /**
+     * clear all registered loggers
+     */
+    public void clear() {
+        for (TestLogger l : loggers.values()) {
+            l.clear();
+        }
+    }
+
     /** get or create the logger */
     @Override
     public TestLogger getLogger(String name) {


### PR DESCRIPTION
For cases where a static `LoggerFactory` is used, e.g. because a `StaticLoggerBinder` is in use, there should be an easy way to clear all known/registered loggers.